### PR TITLE
solve pytest dependancies conflict

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -3,9 +3,4 @@ pip>=21.3.1
 pre-commit==4.5.1
 ruff==0.14.14
 debugpy>=1.8.17
-pycares==5.0.1
-pytest==9.0.2
-pytest-asyncio==1.3.0
-pytest-cov==7.0.0
-pytest-homeassistant-custom-component==0.13.252
-syrupy==4.8.1
+pytest-homeassistant-custom-component==0.13.314


### PR DESCRIPTION
## Description

Removed pytest dependancies, these are now managed by pytest-homeassistant-custom-component (this one stays pinned)

## Related Issue

<!-- If this PR fixes an issue, please link to the issue here -->

Fixes #24 

## Type of Change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project (run `scripts/lint`)
- [x] I have updated the documentation accordingly
- [x] I have updated the translations if needed

## Testing

None

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
